### PR TITLE
Fix empty NBT tag checking

### DIFF
--- a/src/main/java/com/mike_caron/equivalentintegrations/storage/EMCItemHandler.java
+++ b/src/main/java/com/mike_caron/equivalentintegrations/storage/EMCItemHandler.java
@@ -125,7 +125,7 @@ public final class EMCItemHandler
 
             knowledge = ProjectEAPI.getTransmutationProxy().getKnowledgeProviderFor(owner);
 
-            if(forbidNbt && stack.hasTagCompound())
+            if(forbidNbt && stack.hasTagCompound() && !(stack.getTagCompound().toString().length() < 4))
             {
                 return stack;
             }

--- a/src/main/java/com/mike_caron/equivalentintegrations/storage/EMCItemHandler.java
+++ b/src/main/java/com/mike_caron/equivalentintegrations/storage/EMCItemHandler.java
@@ -125,7 +125,7 @@ public final class EMCItemHandler
 
             knowledge = ProjectEAPI.getTransmutationProxy().getKnowledgeProviderFor(owner);
 
-            if(forbidNbt && stack.hasTagCompound() && !(stack.getTagCompound().toString().length() < 4))
+            if(forbidNbt && stack.hasTagCompound() && !(stack.getTagCompound().getSize() == 0))
             {
                 return stack;
             }


### PR DESCRIPTION
If a NBT tag is smaller than 4 characters, the NBT filter will ignore it.